### PR TITLE
[One Workflow][Library] Polish catalog + template preview styling

### DIFF
--- a/src/platform/packages/shared/kbn-workflows-ui/src/library/components/catalog_browser.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/library/components/catalog_browser.tsx
@@ -11,12 +11,13 @@ import {
   EuiButton,
   EuiCallOut,
   EuiFieldSearch,
-  EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
   EuiText,
+  useEuiTheme,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { Template } from '@kbn/workflows-library';
@@ -52,6 +53,21 @@ CenteredMessage.displayName = 'CenteredMessage';
  * services (http via `useWorkflowsApi`, chrome via `useActiveSolution`).
  */
 export const CatalogBrowser = React.memo<CatalogBrowserProps>(({ onSelect }) => {
+  const { euiTheme } = useEuiTheme();
+
+  // Fluid card grid: tracks are at least 260px wide and grow to fill the row, so
+  // the column count scales with the container — ~2 on narrow screens, ~3–4+ on
+  // wider ones. `auto-fill` keeps card widths consistent instead of stretching a
+  // few cards across the whole row.
+  const gridCss = useMemo(
+    () => css`
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(min(100%, 260px), 1fr));
+      gap: ${euiTheme.size.base};
+    `,
+    [euiTheme.size.base]
+  );
+
   const [search, setSearch] = useState('');
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [manualSolution, setManualSolution] = useState<string | undefined>(undefined);
@@ -124,13 +140,11 @@ export const CatalogBrowser = React.memo<CatalogBrowserProps>(({ onSelect }) => 
     );
   } else {
     content = (
-      <EuiFlexGrid columns={3} gutterSize="l" data-test-subj="workflowLibraryCatalogGrid">
+      <div css={gridCss} data-test-subj="workflowLibraryCatalogGrid">
         {templates.map((template) => (
-          <EuiFlexItem key={template.slug}>
-            <TemplateCard template={template} onSelect={onSelect} />
-          </EuiFlexItem>
+          <TemplateCard key={template.slug} template={template} onSelect={onSelect} />
         ))}
-      </EuiFlexGrid>
+      </div>
     );
   }
 
@@ -163,16 +177,16 @@ export const CatalogBrowser = React.memo<CatalogBrowserProps>(({ onSelect }) => 
         <EuiFlexGroup
           data-test-subj="workflowLibraryCatalogBrowser"
           alignItems="flexStart"
-          gutterSize="xl"
+          gutterSize="l"
         >
-          <EuiFlexItem grow={1}>
+          <EuiFlexItem grow={false} css={{ width: 220 }}>
             <CategoryFacets
               templates={facetScopedTemplates}
               selectedCategories={selectedCategories}
               onChange={setSelectedCategories}
             />
           </EuiFlexItem>
-          <EuiFlexItem grow={4}>{content}</EuiFlexItem>
+          <EuiFlexItem grow={1}>{content}</EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/src/platform/packages/shared/kbn-workflows-ui/src/library/components/catalog_template_icons.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/library/components/catalog_template_icons.tsx
@@ -68,7 +68,14 @@ export const CatalogTemplateIcons = React.memo<CatalogTemplateIconsProps>(
     const hasDivider = triggerTypes.length > 0 && visibleStepTypes.length > 0;
 
     return (
-      <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap={false}>
+      <EuiFlexGroup
+        gutterSize="none"
+        alignItems="center"
+        responsive={false}
+        wrap={false}
+        // 12px between logos (8px + 4px); no gutter token for 12px.
+        css={{ gap: euiTheme.size.m }}
+      >
         {triggerTypes.map((triggerType) => (
           <EuiFlexItem grow={false} key={`trigger-${triggerType}`}>
             <TypeIcon type={triggerType} kind="trigger" />

--- a/src/platform/packages/shared/kbn-workflows-ui/src/library/components/category_facets.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/library/components/category_facets.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiFacetButton, EuiFacetGroup } from '@elastic/eui';
+import { EuiFacetButton, EuiFacetGroup, useEuiTheme } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { Template } from '@kbn/workflows-library';
@@ -29,6 +29,16 @@ export interface CategoryFacetsProps {
  */
 export const CategoryFacets = React.memo<CategoryFacetsProps>(
   ({ templates, selectedCategories, onChange }) => {
+    const { euiTheme } = useEuiTheme();
+
+    // Only the selected facet is emphasized; unselected facets keep the default weight.
+    const facetWeightCss = useCallback(
+      (isSelected: boolean) => ({
+        fontWeight: isSelected ? euiTheme.font.weight.semiBold : euiTheme.font.weight.regular,
+      }),
+      [euiTheme.font.weight.semiBold, euiTheme.font.weight.regular]
+    );
+
     const categoryCounts = useMemo(() => {
       const counts = new Map<string, number>();
       for (const template of templates) {
@@ -63,6 +73,7 @@ export const CategoryFacets = React.memo<CategoryFacetsProps>(
             quantity={templates.length}
             isSelected={selectedCategories.length === 0}
             onClick={clearCategories}
+            css={facetWeightCss(selectedCategories.length === 0)}
             data-test-subj="workflowLibraryCategoryFacet-all"
           >
             {i18n.translate('workflows.library.categoryFacets.allCategories', {
@@ -75,6 +86,7 @@ export const CategoryFacets = React.memo<CategoryFacetsProps>(
               quantity={count}
               isSelected={selectedCategories.includes(id)}
               onClick={() => toggleCategory(id)}
+              css={facetWeightCss(selectedCategories.includes(id))}
               data-test-subj={`workflowLibraryCategoryFacet-${id}`}
             >
               {humanizeCategoryId(id)}

--- a/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_card.test.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_card.test.tsx
@@ -36,8 +36,10 @@ describe('TemplateCard', () => {
 
     expect(screen.getByText('IP Reputation Check')).toBeInTheDocument();
     expect(screen.getByText('Assess the reputation of an IP address.')).toBeInTheDocument();
-    expect(screen.getByText('enrichment')).toBeInTheDocument();
-    expect(screen.getByText('threat-intel')).toBeInTheDocument();
+    // Tags render in both the visible row and the off-screen measuring row used
+    // to compute one-line overflow, so there can be more than one match.
+    expect(screen.getAllByText('enrichment').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('threat-intel').length).toBeGreaterThan(0);
   });
 
   it('sets the expected data-test-subj', () => {

--- a/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_card.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_card.tsx
@@ -7,11 +7,19 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { EuiBadge, EuiCard, EuiFlexGroup, EuiFlexItem, EuiText, useEuiTheme } from '@elastic/eui';
+import {
+  EuiCard,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  useEuiShadow,
+  useEuiTheme,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import React, { useCallback, useMemo } from 'react';
 import type { Template } from '@kbn/workflows-library';
 import { CatalogTemplateIcons } from './catalog_template_icons';
+import { TemplateCardTags } from './template_card_tags';
 
 export interface TemplateCardProps {
   template: Template;
@@ -20,12 +28,33 @@ export interface TemplateCardProps {
 
 export const TemplateCard = React.memo<TemplateCardProps>(({ template, onSelect }) => {
   const { euiTheme } = useEuiTheme();
+  const hoverShadow = useEuiShadow('s');
+
+  // Border-only at rest; a light shadow appears only on hover/keyboard focus.
+  // The two logical gaps — logos → (title + description) → tags — both use the
+  // `size.l` token so they stay equal. EuiCard styles its footer slot with an
+  // Emotion label (class `css-…-euiCard__footer`), so it must be matched with a
+  // substring attribute selector, not `.euiCard__footer`.
+  const cardCss = useMemo(
+    () =>
+      css`
+        transition: box-shadow ${euiTheme.animation.fast} ease-in;
+        &:hover,
+        &:focus-within {
+          ${hoverShadow}
+        }
+        [class*='euiCard__footer'] {
+          margin-top: ${euiTheme.size.l};
+        }
+      `,
+    [hoverShadow, euiTheme.animation.fast, euiTheme.size.l]
+  );
 
   const handleClick = useCallback(() => onSelect(template), [onSelect, template]);
 
   const title = useMemo(
     () => (
-      <EuiFlexGroup direction="column" gutterSize="m" responsive={false}>
+      <EuiFlexGroup direction="column" gutterSize="l" responsive={false}>
         <EuiFlexItem grow={false}>
           <CatalogTemplateIcons
             stepTypes={template.stepTypes}
@@ -33,7 +62,16 @@ export const TemplateCard = React.memo<TemplateCardProps>(({ template, onSelect 
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiText size="m" css={css({ fontWeight: euiTheme.font.weight.semiBold })}>
+          <EuiText
+            size="m"
+            css={css`
+              font-weight: ${euiTheme.font.weight.semiBold};
+              display: -webkit-box;
+              -webkit-line-clamp: 2;
+              -webkit-box-orient: vertical;
+              overflow: hidden;
+            `}
+          >
             {template.name}
           </EuiText>
         </EuiFlexItem>
@@ -42,16 +80,27 @@ export const TemplateCard = React.memo<TemplateCardProps>(({ template, onSelect 
     [template.stepTypes, template.triggerTypes, template.name, euiTheme.font.weight.semiBold]
   );
 
+  // Clamp the description to at most two lines; overflow is truncated with an ellipsis.
+  const description = useMemo(
+    () => (
+      <span
+        css={css`
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        `}
+      >
+        {template.description}
+      </span>
+    ),
+    [template.description]
+  );
+
   const footer = useMemo(
     () =>
       template.categories.length > 0 ? (
-        <EuiFlexGroup gutterSize="xs" wrap responsive={false}>
-          {template.categories.map((category) => (
-            <EuiFlexItem grow={false} key={category}>
-              <EuiBadge color="hollow">{category}</EuiBadge>
-            </EuiFlexItem>
-          ))}
-        </EuiFlexGroup>
+        <TemplateCardTags categories={template.categories} />
       ) : undefined,
     [template.categories]
   );
@@ -62,10 +111,12 @@ export const TemplateCard = React.memo<TemplateCardProps>(({ template, onSelect 
       layout="vertical"
       textAlign="left"
       paddingSize="l"
+      hasBorder
       onClick={handleClick}
       title={title}
-      description={template.description}
+      description={description}
       footer={footer}
+      css={cardCss}
     />
   );
 });

--- a/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_card_tags.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_card_tags.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { EuiBadge, useEuiTheme, useResizeObserver } from '@elastic/eui';
+import { css } from '@emotion/react';
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+export interface TemplateCardTagsProps {
+  categories: string[];
+}
+
+/**
+ * Renders a template's category tags on a single row. Tags that don't fit are
+ * collapsed into a trailing "+N" counter badge (e.g. `root-cause-analysis`,
+ * `ai-agent` `+1`). The fit is measured against the available width and
+ * recomputed whenever the card resizes.
+ */
+export const TemplateCardTags = React.memo<TemplateCardTagsProps>(({ categories }) => {
+  const { euiTheme } = useEuiTheme();
+  const gap = euiTheme.size.xs;
+
+  // Callback ref (via state) so useResizeObserver starts observing once the node
+  // mounts and re-runs when its width changes.
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const measureRef = useRef<HTMLDivElement | null>(null);
+  const { width: containerWidth } = useResizeObserver(container);
+
+  const [visibleCount, setVisibleCount] = useState(categories.length);
+
+  useLayoutEffect(() => {
+    const measureEl = measureRef.current;
+    if (!measureEl || containerWidth === 0) {
+      return;
+    }
+    const gapPx = parseFloat(gap);
+    const tagWidths = Array.from(measureEl.querySelectorAll<HTMLElement>('[data-tag-measure]')).map(
+      (el) => el.getBoundingClientRect().width
+    );
+    const overflowEl = measureEl.querySelector<HTMLElement>('[data-overflow-measure]');
+    const overflowWidth = overflowEl ? overflowEl.getBoundingClientRect().width : 0;
+
+    // Greedily fit tags left-to-right on one row.
+    let used = 0;
+    let count = 0;
+    for (const width of tagWidths) {
+      const next = width + (count > 0 ? gapPx : 0);
+      if (used + next > containerWidth) {
+        break;
+      }
+      used += next;
+      count += 1;
+    }
+
+    // If some tags overflow, reserve room for the "+N" counter on the same row,
+    // dropping trailing tags until it fits.
+    if (count < tagWidths.length) {
+      while (count > 0 && used + gapPx + overflowWidth > containerWidth) {
+        count -= 1;
+        used -= tagWidths[count] + (count > 0 ? gapPx : 0);
+      }
+    }
+
+    // Always keep at least one tag visible so the row is never just a counter.
+    setVisibleCount(tagWidths.length > 0 ? Math.max(count, 1) : 0);
+  }, [containerWidth, gap, categories]);
+
+  const overflowCount = categories.length - visibleCount;
+
+  const rowCss = useMemo(
+    () => css`
+      display: flex;
+      gap: ${gap};
+      overflow: hidden;
+      inline-size: 100%;
+    `,
+    [gap]
+  );
+
+  if (categories.length === 0) {
+    return null;
+  }
+
+  return (
+    <div css={css({ position: 'relative', inlineSize: '100%' })}>
+      {/* Off-screen measuring row: every tag plus a worst-case counter, at natural width. */}
+      <div
+        ref={measureRef}
+        aria-hidden
+        css={css`
+          position: absolute;
+          inset-block-start: 0;
+          inset-inline-start: 0;
+          display: flex;
+          visibility: hidden;
+          pointer-events: none;
+          white-space: nowrap;
+        `}
+      >
+        {categories.map((category) => (
+          <EuiBadge key={category} data-tag-measure color="hollow">
+            {category}
+          </EuiBadge>
+        ))}
+        <EuiBadge data-overflow-measure color="hollow">{`+${categories.length}`}</EuiBadge>
+      </div>
+
+      <div ref={setContainer} css={rowCss}>
+        {categories.slice(0, visibleCount).map((category) => (
+          <EuiBadge key={category} color="hollow">
+            {category}
+          </EuiBadge>
+        ))}
+        {overflowCount > 0 && (
+          <EuiBadge color="hollow" title={categories.slice(visibleCount).join(', ')}>
+            {`+${overflowCount}`}
+          </EuiBadge>
+        )}
+      </div>
+    </div>
+  );
+});
+TemplateCardTags.displayName = 'TemplateCardTags';

--- a/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_detail.test.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_detail.test.tsx
@@ -7,7 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import React from 'react';
 import type { TemplateBody } from '@kbn/workflows-library';
 import { TemplateDetail } from './template_detail';
@@ -82,16 +82,20 @@ describe('TemplateDetail', () => {
     renderDetail();
     expect(screen.getByRole('heading', { name: 'My Template' })).toBeInTheDocument();
     expect(screen.getByText('Does useful things.')).toBeInTheDocument();
-    expect(screen.getByTestId('workflowLibraryTemplateDetail-version')).toHaveTextContent('v1.2.0');
+    expect(screen.getByTestId('workflowLibraryTemplateDetail-version')).toHaveTextContent('1.2.0');
   });
 
-  it('should render humanized category badges and the solution badge under their labels', () => {
+  it('should render the solution logo and humanized tag badges under the title', () => {
     renderDetail();
-    expect(screen.getByText('Solutions:')).toBeInTheDocument();
-    expect(screen.getByText('Categories:')).toBeInTheDocument();
-    expect(screen.getByText('Threat Intel')).toBeInTheDocument();
-    expect(screen.getByText('Enrichment')).toBeInTheDocument();
-    expect(screen.getByText('Security')).toBeInTheDocument();
+    expect(screen.getByText('Solutions')).toBeInTheDocument();
+    // Solutions render as product logos (name shown on hover), not text.
+    expect(
+      screen.getByTestId('workflowLibraryTemplateDetail-solution-security')
+    ).toBeInTheDocument();
+    // Categories render as tags under the title (humanized).
+    const tags = screen.getByTestId('workflowLibraryTemplateDetail-tags');
+    expect(within(tags).getByText('Threat Intel')).toBeInTheDocument();
+    expect(within(tags).getByText('Enrichment')).toBeInTheDocument();
   });
 
   it('should call onLoaded with the loaded template', () => {

--- a/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_detail.tsx
+++ b/src/platform/packages/shared/kbn-workflows-ui/src/library/components/template_detail.tsx
@@ -12,13 +12,13 @@ import {
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIconTip,
   EuiLoadingSpinner,
-  EuiSpacer,
-  EuiText,
-  EuiTitle,
+  useEuiShadow,
   useEuiTheme,
 } from '@elastic/eui';
 import type { IconType } from '@elastic/eui';
+import { css } from '@emotion/react';
 import React, { useEffect, useMemo } from 'react';
 import { i18n } from '@kbn/i18n';
 import { renderTemplate } from '@kbn/workflows-library';
@@ -33,6 +33,12 @@ export interface TemplateDetailProps {
   slug: string;
   /** Called once the template body has loaded — e.g. to set breadcrumbs. */
   onLoaded?: (template: TemplateBody) => void;
+  /**
+   * Rendered at the top of the left column (e.g. a "Back to library" link). Kept
+   * as a slot so navigation stays in the host app while this component owns the
+   * full two-column layout (letting the preview panel reach the top of the page).
+   */
+  backButton?: React.ReactNode;
 }
 
 /** App icons for the known solutions; unknown solutions render without one. */
@@ -50,9 +56,10 @@ const capitalize = (value: string): string =>
  * and category badges, step/trigger icons) plus a read-only preview of the
  * template's workflow definition.
  */
-export const TemplateDetail = React.memo<TemplateDetailProps>(({ slug, onLoaded }) => {
+export const TemplateDetail = React.memo<TemplateDetailProps>(({ slug, onLoaded, backButton }) => {
   const { data, isLoading, isError } = useTemplate(slug);
   const { euiTheme } = useEuiTheme();
+  const previewShadow = useEuiShadow('xl');
 
   const previewYaml = useMemo(() => (data ? renderTemplate({ template: data }) : ''), [data]);
   const { stepTypes, triggerTypes } = useMemo(
@@ -88,131 +95,244 @@ export const TemplateDetail = React.memo<TemplateDetailProps>(({ slug, onLoaded 
   // No specific solutions listed means all solutions are supported
   const solutions = metadata.solutions?.length ? metadata.solutions : Object.keys(SOLUTION_ICONS);
 
+  const styles = {
+    // Left column holds the back link + metadata; nudged down so the back link
+    // sits a little below the top while the preview panel reaches the top edge.
+    leftColumn: css({ width: '30%', paddingTop: euiTheme.size.l }),
+    // 48px between the back link and the icons row (Figma "Content Container" gap).
+    leftStack: css({ gap: euiTheme.size.xxxl }),
+    // 32px between the title block and the details block (Figma "Container" gap).
+    header: css({ gap: euiTheme.size.xl }),
+    // 16px between the icons row and the title row (Figma "Title" gap).
+    titleBlock: css({ gap: euiTheme.size.base }),
+    // 8px between the title and the version badge (Figma "Main" gap).
+    titleRow: css({ gap: euiTheme.size.s }),
+    // 16px between the title and the tags below it.
+    titleAndTags: css({ gap: euiTheme.size.base }),
+    title: css({
+      margin: 0,
+      fontWeight: euiTheme.font.weight.semiBold,
+      fontSize: '24px',
+      lineHeight: '28px',
+      color: euiTheme.colors.textHeading,
+    }),
+    // 16px between the info card and the description (Figma "Details" gap).
+    details: css({ gap: euiTheme.size.base }),
+    // Bordered, rounded metadata card: 12px/16px padding, 16px between columns.
+    infoCard: css({
+      display: 'flex',
+      gap: euiTheme.size.base,
+      padding: `${euiTheme.size.m} ${euiTheme.size.base}`,
+      border: `${euiTheme.border.width.thin} solid ${euiTheme.colors.borderBaseSubdued}`,
+      borderRadius: euiTheme.border.radius.medium,
+    }),
+    infoBlock: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: euiTheme.size.xs,
+      // Solutions and Version each take an equal (50%) share of the card.
+      flexGrow: 1,
+      flexBasis: 0,
+      minWidth: 0,
+    }),
+    infoLabel: css({
+      fontWeight: euiTheme.font.weight.medium,
+      fontSize: '12px',
+      lineHeight: '20px',
+      color: euiTheme.colors.textSubdued,
+    }),
+    badgeRow: css({
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: euiTheme.size.xs,
+      alignItems: 'center',
+    }),
+    // Solutions shown as product logos only (name on hover).
+    solutionRow: css({
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: euiTheme.size.s,
+      alignItems: 'center',
+    }),
+    divider: css({
+      width: euiTheme.border.width.thin,
+      alignSelf: 'stretch',
+      backgroundColor: euiTheme.colors.borderBaseSubdued,
+    }),
+    infoValue: css({
+      fontWeight: euiTheme.font.weight.bold,
+      fontSize: '14px',
+      lineHeight: '24px',
+      color: euiTheme.colors.text,
+    }),
+    description: css({
+      margin: 0,
+      fontSize: '14px',
+      lineHeight: '24px',
+      color: euiTheme.colors.text,
+    }),
+    // Preview panel fills the row height; its 8px top/right/bottom margins come
+    // from the page's content padding. Relative so the "Preview" pill can float.
+    panel: css({
+      position: 'relative',
+      minHeight: 0,
+      border: `${euiTheme.border.width.thin} solid ${euiTheme.colors.borderBaseSubdued}`,
+      backgroundColor: euiTheme.colors.backgroundBaseSubdued,
+    }),
+    // "Preview" pill floats centered over the top of the editor (16px down).
+    previewBadge: css({
+      position: 'absolute',
+      insetBlockStart: euiTheme.size.base,
+      insetInlineStart: '50%',
+      transform: 'translateX(-50%)',
+      zIndex: 2,
+    }),
+    // Editor fills the panel; 8px inset on top/right/bottom, left keeps Monaco's gutter.
+    editorInset: css({
+      flexGrow: 1,
+      minHeight: 0,
+      overflow: 'hidden',
+      padding: `${euiTheme.size.s} ${euiTheme.size.s} ${euiTheme.size.s} 0`,
+    }),
+  };
+
   return (
     <EuiFlexGroup
-      direction="column"
-      gutterSize="m"
+      // 24px gutter so the left column has matching 24px padding on both sides
+      // (its left comes from the page content padding).
+      gutterSize="l"
+      alignItems="stretch"
       data-test-subj="workflowLibraryTemplateDetail"
       css={{ height: '100%' }}
     >
-      <EuiFlexItem>
-        <EuiFlexGroup gutterSize="m" alignItems="flexStart">
-          <EuiFlexItem grow={false} css={{ width: '30%' }}>
-            <EuiFlexGroup direction="column" gutterSize="m">
+      <EuiFlexItem grow={false} css={styles.leftColumn}>
+        <EuiFlexGroup direction="column" gutterSize="none" css={styles.leftStack}>
+          {backButton ? (
+            // Shrink-wrap + align left so the button's label isn't centered by the
+            // full-width column (EuiButtonEmpty centers its content otherwise).
+            <EuiFlexItem grow={false} css={{ alignItems: 'flex-start' }}>
+              {backButton}
+            </EuiFlexItem>
+          ) : null}
+
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup direction="column" gutterSize="none" css={styles.header}>
+              {/* Title block: icons, then title + version, then tags (Figma order). */}
               <EuiFlexItem grow={false}>
-                <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false} wrap>
+                <EuiFlexGroup direction="column" gutterSize="none" css={styles.titleBlock}>
                   <EuiFlexItem grow={false}>
-                    <EuiTitle size="l">
-                      <h1>{metadata.name}</h1>
-                    </EuiTitle>
+                    <CatalogTemplateIcons stepTypes={stepTypes} triggerTypes={triggerTypes} />
                   </EuiFlexItem>
                   <EuiFlexItem grow={false}>
-                    <EuiBadge color="hollow" data-test-subj="workflowLibraryTemplateDetail-version">
-                      {i18n.translate('workflows.library.templateDetail.version', {
-                        defaultMessage: 'v{version}',
-                        values: { version: metadata.version },
-                      })}
-                    </EuiBadge>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
+                    <EuiFlexGroup direction="column" gutterSize="none" css={styles.titleAndTags}>
+                      <EuiFlexItem grow={false}>
+                        <h1 css={styles.title}>{metadata.name}</h1>
+                      </EuiFlexItem>
 
-              <EuiFlexItem grow={false}>
-                <CatalogTemplateIcons stepTypes={stepTypes} triggerTypes={triggerTypes} />
-              </EuiFlexItem>
-
-              <EuiFlexItem grow={false}>
-                <EuiText color="subdued">{metadata.description}</EuiText>
-              </EuiFlexItem>
-
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup gutterSize="s" alignItems="center">
-                  <EuiFlexItem grow={false}>
-                    <EuiText size="xs">
-                      <strong>
-                        {i18n.translate('workflows.library.templateDetail.solutionsLabel', {
-                          defaultMessage: 'Solutions:',
-                        })}
-                      </strong>
-                    </EuiText>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiFlexGroup
-                      gutterSize="xs"
-                      wrap
-                      responsive={false}
-                      data-test-subj="workflowLibraryTemplateDetail-solutions"
-                    >
-                      {solutions.map((solution) => (
-                        <EuiFlexItem grow={false} key={`solution-${solution}`}>
-                          <EuiBadge color="hollow" iconType={SOLUTION_ICONS[solution]}>
-                            {capitalize(solution)}
-                          </EuiBadge>
+                      {metadata.categories.length > 0 ? (
+                        <EuiFlexItem grow={false}>
+                          <div
+                            css={styles.badgeRow}
+                            data-test-subj="workflowLibraryTemplateDetail-tags"
+                          >
+                            {metadata.categories.map((category) => (
+                              <EuiBadge key={`tag-${category}`} color="hollow">
+                                {humanizeCategoryId(category)}
+                              </EuiBadge>
+                            ))}
+                          </div>
                         </EuiFlexItem>
-                      ))}
+                      ) : null}
                     </EuiFlexGroup>
                   </EuiFlexItem>
                 </EuiFlexGroup>
+              </EuiFlexItem>
 
-                <EuiSpacer size="s" />
-
-                <EuiFlexGroup gutterSize="s" alignItems="center">
+              {/* Details block: solutions info card, then description. */}
+              <EuiFlexItem grow={false}>
+                <EuiFlexGroup direction="column" gutterSize="none" css={styles.details}>
                   <EuiFlexItem grow={false}>
-                    <EuiText size="xs">
-                      <strong>
-                        {i18n.translate('workflows.library.templateDetail.categoriesLabel', {
-                          defaultMessage: 'Categories:',
-                        })}
-                      </strong>
-                    </EuiText>
+                    <div css={styles.infoCard}>
+                      <div
+                        css={styles.infoBlock}
+                        data-test-subj="workflowLibraryTemplateDetail-solutions"
+                      >
+                        <span css={styles.infoLabel}>
+                          {i18n.translate('workflows.library.templateDetail.solutionsLabel', {
+                            defaultMessage: 'Solutions',
+                          })}
+                        </span>
+                        <div css={styles.solutionRow}>
+                          {solutions.map((solution) => {
+                            const label = capitalize(solution);
+                            const icon = SOLUTION_ICONS[solution];
+                            return icon ? (
+                              <EuiIconTip
+                                key={`solution-${solution}`}
+                                type={icon}
+                                size="m"
+                                content={label}
+                                aria-label={label}
+                                iconProps={{
+                                  'data-test-subj': `workflowLibraryTemplateDetail-solution-${solution}`,
+                                }}
+                              />
+                            ) : (
+                              <EuiBadge key={`solution-${solution}`} color="hollow">
+                                {label}
+                              </EuiBadge>
+                            );
+                          })}
+                        </div>
+                      </div>
+
+                      <div css={styles.divider} />
+
+                      <div
+                        css={styles.infoBlock}
+                        data-test-subj="workflowLibraryTemplateDetail-version"
+                      >
+                        <span css={styles.infoLabel}>
+                          {i18n.translate('workflows.library.templateDetail.versionLabel', {
+                            defaultMessage: 'Version',
+                          })}
+                        </span>
+                        <span css={styles.infoValue}>{metadata.version}</span>
+                      </div>
+                    </div>
                   </EuiFlexItem>
+
                   <EuiFlexItem grow={false}>
-                    <EuiFlexGroup
-                      gutterSize="xs"
-                      wrap
-                      responsive={false}
-                      data-test-subj="workflowLibraryTemplateDetail-categories"
-                    >
-                      {metadata.categories.map((category) => (
-                        <EuiFlexItem grow={false} key={`category-${category}`}>
-                          <EuiBadge color="hollow">{humanizeCategoryId(category)}</EuiBadge>
-                        </EuiFlexItem>
-                      ))}
-                    </EuiFlexGroup>
+                    <p css={styles.description}>{metadata.description}</p>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
 
-          <EuiFlexItem
-            css={{
-              height: '100%',
-              border: `1px solid ${euiTheme.colors.borderBaseSubdued}`,
-              backgroundColor: euiTheme.colors.backgroundBaseSubdued,
-            }}
+      {/* Preview panel: editor fills the height; the "Preview" pill floats on top. */}
+      <EuiFlexItem css={styles.panel}>
+        <div css={styles.previewBadge}>
+          <EuiBadge
+            color="warning"
+            css={css(previewShadow)}
+            style={{ padding: `0 ${euiTheme.size.l}` }}
           >
-            <EuiFlexGroup direction="column" gutterSize="none">
-              <EuiFlexItem grow={false}>
-                <EuiFlexGroup direction="column" alignItems="center">
-                  <EuiFlexItem grow={false} css={{ padding: `${euiTheme.size.s} 0` }}>
-                    <EuiBadge color="warning" style={{ padding: `0 ${euiTheme.size.l}` }}>
-                      {i18n.translate('workflows.library.templateDetail.previewTitle', {
-                        defaultMessage: 'Preview',
-                      })}
-                    </EuiBadge>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFlexItem>
+            {i18n.translate('workflows.library.templateDetail.previewTitle', {
+              defaultMessage: 'Preview',
+            })}
+          </EuiBadge>
+        </div>
 
-              <EuiFlexItem grow css={{ minHeight: 0, overflow: 'hidden' }}>
-                <WorkflowYamlPreview
-                  yaml={previewYaml}
-                  height="100%"
-                  data-test-subj="workflowLibraryTemplateDetail-preview"
-                />
-              </EuiFlexItem>
-            </EuiFlexGroup>
+        <EuiFlexGroup direction="column" gutterSize="none" css={{ height: '100%' }}>
+          <EuiFlexItem grow css={styles.editorInset}>
+            <WorkflowYamlPreview
+              yaml={previewYaml}
+              height="100%"
+              data-test-subj="workflowLibraryTemplateDetail-preview"
+            />
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>

--- a/src/platform/plugins/shared/workflows_management/public/pages/library/template_detail_page.tsx
+++ b/src/platform/plugins/shared/workflows_management/public/pages/library/template_detail_page.tsx
@@ -83,35 +83,37 @@ export const LibraryTemplateDetailPage = React.memo<LibraryTemplateDetailPagePro
     return <Redirect to="/" />;
   }
 
+  const backButton = (
+    <EuiButtonEmpty
+      size="xs"
+      flush="left"
+      iconType="arrowLeft"
+      onClick={goToLibrary}
+      data-test-subj="workflowLibraryTemplateDetailBackButton"
+    >
+      {backToLibraryLabel}
+    </EuiButtonEmpty>
+  );
+
   return (
     <EuiFlexGroup
       direction="column"
       gutterSize="none"
-      alignItems="flexStart"
       // Full-height pages (like the workflow editor) don't use EuiPageTemplate
       css={[kbnFullBodyHeightCss(), css({ backgroundColor: euiTheme.colors.backgroundBasePlain })]}
       data-test-subj="workflowLibraryTemplateDetailPage"
     >
-      <EuiFlexItem grow={false} css={css({ padding: `${euiTheme.size.l} ${euiTheme.size.l} 0` })}>
-        <EuiButtonEmpty
-          size="xs"
-          flush="left"
-          iconType="arrowLeft"
-          onClick={goToLibrary}
-          data-test-subj="workflowLibraryTemplateDetailBackButton"
-        >
-          {backToLibraryLabel}
-        </EuiButtonEmpty>
-      </EuiFlexItem>
       <EuiFlexItem
         css={css({
           minHeight: 0,
           overflow: 'hidden',
-          padding: `${euiTheme.size.m} ${euiTheme.size.l} ${euiTheme.size.l}`,
+          // 8px around the preview panel (top/right/bottom); wider on the left for
+          // the metadata column. The panel fills the height and scrolls internally.
+          padding: `${euiTheme.size.s} ${euiTheme.size.s} ${euiTheme.size.s} ${euiTheme.size.l}`,
           width: '100%',
         })}
       >
-        <TemplateDetail slug={slug} onLoaded={handleTemplateLoaded} />
+        <TemplateDetail slug={slug} onLoaded={handleTemplateLoaded} backButton={backButton} />
       </EuiFlexItem>
     </EuiFlexGroup>
   );


### PR DESCRIPTION
Styling refinements stacked on top of #276229 (elastic#276229) for the Workflow Template Library — catalog page and template preview.

### Catalog (library main page)
- Fixed **220px** category sidebar; only the **selected** facet is `semiBold`
- Sidebar ↔ grid gap → **24px**
- **Fluid responsive card grid** (`auto-fill` + `minmax`), 16px gutters
- **Template cards**: border-only with a light **hover** shadow; **title** and **description** each clamped to **2 lines**; three logical blocks (logos / title+description / tags) with 24px gaps
- Card **tags collapse to one row** with a `+N` overflow counter (new `TemplateCardTags`)

### Template detail page
- Two-column layout; **preview panel fills the height** with **8px** margins and scrolls internally
- **"Preview" pill floats** over the editor with a shadow; 8px editor inset
- **"Back to library"** moved into the left column, left-aligned, **48px** above the logo row; left column has matching **24px** padding on both sides
- Figma-aligned typography/spacing (title, tags under the title, description using the `text` color token)
- **Info card**: Solutions (product **logos**, name on hover) and **Version** each take **50%**, split by a divider
- Step/trigger logo row gap → **12px**

All changes are UI-only. Type check, ESLint, and the `template_card` / `template_detail` Jest suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)